### PR TITLE
Add seq export format

### DIFF
--- a/public/menu.js
+++ b/public/menu.js
@@ -14,7 +14,8 @@ const exporters = [
   { label: 'GIF (.gif)', cmd: 'export-gif' },
   { label: 'JSON (.json)', cmd: 'export-json' },
   { label: 'PETSCII (.c)', cmd: 'export-marq-c' },
-  { label: 'PNG (.png)', cmd: 'export-png' }
+  { label: 'PNG (.png)', cmd: 'export-png' },
+  { label: 'SEQ (.seq)', cmd: 'export-seq' }
 ]
 
 module.exports = class MenuBuilder {

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,6 +110,9 @@ electron.ipcRenderer.on('menu', (_event: Event, message: string) => {
     case 'export-png':
       dispatchExport(formats.png)
       return
+    case 'export-seq':
+      dispatchExport(formats.seq)
+      return
     case 'export-marq-c':
       dispatchExport(formats.c)
       return

--- a/src/redux/typesExport.ts
+++ b/src/redux/typesExport.ts
@@ -40,6 +40,11 @@ export interface FileFormatC extends FileFormatBase {
   ext: 'c';
 }
 
+export interface FileFormatSeq extends FileFormatBase {
+  ext: 'seq';
+}
+
+
 export interface FileFormatD64 extends FileFormatBase {
   ext: 'd64';
 }
@@ -72,3 +77,4 @@ export type FileFormat =
   | FileFormatPrg
   | FileFormatBas
   | FileFormatJson
+  | FileFormatSeq

--- a/src/utils/exporters/index.ts
+++ b/src/utils/exporters/index.ts
@@ -9,6 +9,7 @@ import { saveBASIC } from './basic'
 import { saveGIF } from './gif'
 import { savePNG } from './png'
 import { saveJSON } from './json'
+import { saveSEQ } from './seq'
 
 import { fs } from '../electronImports'
 
@@ -135,6 +136,7 @@ export {
   saveAsm,
   saveBASIC,
   saveGIF,
-  saveJSON
+  saveJSON,
+  saveSEQ
 }
 

--- a/src/utils/exporters/seq.ts
+++ b/src/utils/exporters/seq.ts
@@ -1,0 +1,120 @@
+
+import { FileFormatSeq, Framebuf, FramebufWithFont } from '../../redux/types'
+import { fs } from '../electronImports'
+
+const seq_colors: number[]=[
+  0x90, //black
+  0x05, //white
+  0x1c, //red
+  0x9f, //cyan
+  0x9c, //purple
+  0x1e, //green
+  0x1f, //blue
+  0x9e, //yellow
+  0x81, //orange
+  0x95, //brown
+  0x96, //pink
+  0x97, //grey 1
+  0x98, //grey 2
+  0x99, //lt green
+  0x9a, //lt blue
+  0x9b //grey 3
+]
+
+function convertToSEQ(fb: Framebuf, bytes:number[]) {
+  const { width, height, framebuf } = fb
+  let currcolor = -1
+  let currev = false
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      let byte_color = framebuf[y][x].color
+      if (byte_color != currcolor) {
+        bytes.push(seq_colors[byte_color])
+        currcolor = byte_color
+      }
+      let byte_char = framebuf[y][x].code
+      if(byte_char>=0x80){
+        if (!currev){
+          bytes.push(0x12)
+          currev = true
+        }
+        byte_char &= 0x7f
+      } else {
+        if (currev) {
+          bytes.push(0x92)
+          currev = false
+        }
+      }
+      if ((byte_char >= 0) && (byte_char <= 0x1f)){
+        byte_char = byte_char + 0x40
+      }
+      else
+      {
+          if ((byte_char >= 0x40) && (byte_char <= 0x5d))
+          {
+            byte_char = byte_char + 0x80
+          }
+          else
+          {
+              if (byte_char == 0x5e) {
+                byte_char = 0xff
+              }
+              else
+              {
+                  if (byte_char == 0x95)
+                  {
+                    byte_char = 0xdf
+                  }
+                  else
+                  {
+                      if ((byte_char >= 0x60) && (byte_char <= 0x7f))
+                      {
+                        byte_char = byte_char + 0x80
+                      }
+                      else
+                      {
+                          if ((byte_char >= 0x80) && (byte_char <= 0xbf))
+                          {
+                            byte_char = byte_char - 0x80
+                          }
+                          else
+                          {
+                              if ((byte_char >= 0xc0) && (byte_char <= 0xff))
+                              {
+                                byte_char = byte_char -0x40
+                              }
+                          }
+                      }
+                  }
+              }
+          }
+      }
+      bytes.push(byte_char)
+
+    }
+  }
+}
+
+const  saveSEQ = (filename: string, fb: FramebufWithFont, fmt: FileFormatSeq) => {
+  try {
+    let bytes:number[] = []
+    console.log(fmt) // placeholder for future use
+    convertToSEQ(fb, bytes)
+    let length = bytes.length
+    let buff = new Buffer(length)
+    for(var i = 0; i < length; i++) {
+      buff.writeUInt8(bytes[i], i)
+    }
+    let fd = fs.openSync(filename, 'w')
+    fs.write(fd, buff, 0, buff.length, 0, function(err:any, written:any) {
+      console.log('err', err)
+      console.log('written', written)
+    })
+  }
+  catch(e) {
+    alert(`Failed to save file '${filename}'!`);
+    console.error(e);
+  }
+}
+
+export { saveSEQ }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -7,7 +7,8 @@ import {
   saveAsm,
   saveBASIC,
   saveGIF,
-  saveJSON
+  saveJSON,
+  saveSEQ
 } from './exporters'
 
 import {
@@ -45,6 +46,11 @@ export const formats: { [index: string]: FileFormat } = {
       alphaPixel: false,
       doublePixels: false
     }
+  },
+  seq: {
+    name: 'PETSCII .seq',
+    ext: 'seq',
+    commonExportParams: defaultExportCommon,
   },
   c: {
     name: 'PETSCII .c',
@@ -155,6 +161,8 @@ const saveFramebufs = (fmt: FileFormat, filename: string, framebufs: FramebufWit
   const selectedFramebuf = framebufs[selectedFramebufIndex];
   if (fmt.ext == 'png') {
     return savePNG(filename, selectedFramebuf, palette, fmt);
+  } else if (fmt.ext == 'seq') {
+    return saveSEQ(filename, selectedFramebuf, fmt);
   } else if (fmt.ext  == 'gif') {
     return saveGIF(filename, framebufs, palette, fmt);
   } else if (fmt.ext == 'c') {


### PR DESCRIPTION
After being bitten by git and its commit history management (again), I've decided to nuke my fork and reapply changed files. I've closed the previous PR in order to open this one.

The previous PR description still apply, as modified files are the same:
Recently I was asked to create a PETSCII logo for a bbs and I needed to save my file in seq format. Due to lack of support for this format in petmate I had to save my file in an intermediate .c format and open it in Marq's PETSCII editor in order to get a seq export. Luckily enough, sources for seq export are available, so I decided to integrate them into petmate as an exercise (and because I'm a bit lazy and I don't want to jump from an editor to another :) )
I've noticed that issue #99 was closed due to the lack of specifications, I don't know if this particular implementation meets some official standards (if any), but I can say that files generated with it can be used in bbs.