### PR TITLE
Seq options

### DIFF
--- a/src/containers/ExportModal.tsx
+++ b/src/containers/ExportModal.tsx
@@ -131,6 +131,7 @@ class SEQExportForm extends Component<SEQExportFormatProps> {
         <br/>
         <br/>
         <Checkbox name='insCR' label='Insert Carriage Returns (0x0D) at end of row' />
+        <Checkbox name='insClear' label='Insert CLS (0x93) at start of file' />
       </Form>
     )
   }
@@ -306,6 +307,7 @@ class ExportModal_ extends Component<ExportModalProps & ExportModalDispatch, Exp
   state: ExportModalState = {
     seq: {
       insCR: false,
+      insClear: true
     },
     png: {
       borders: true,

--- a/src/containers/ExportModal.tsx
+++ b/src/containers/ExportModal.tsx
@@ -14,7 +14,7 @@ import * as toolbar from '../redux/toolbar'
 import * as ReduxRoot from '../redux/root'
 
 import * as utils from '../utils'
-import { FileFormatGif, FileFormatPng, FileFormatAsm, FileFormatBas, FileFormatJson, FileFormat, RootState } from '../redux/types';
+import { FileFormatGif, FileFormatPng, FileFormatSeq, FileFormatAsm, FileFormatBas, FileFormatJson, FileFormat, RootState } from '../redux/types';
 import { bindActionCreators } from 'redux';
 
 const ModalTitle: SFC<{}> = ({children}) => <h2>{children}</h2>
@@ -119,6 +119,24 @@ class PNGExportForm extends Component<PNGExportFormatProps> {
   }
 }
 
+interface SEQExportFormatProps extends ExportPropsBase {
+  state: FileFormatSeq['exportOptions'];
+}
+
+class SEQExportForm extends Component<SEQExportFormatProps> {
+  render () {
+    return (
+      <Form state={this.props.state} setField={this.props.setField}>
+        <Title>SEQ export options</Title>
+        <br/>
+        <br/>
+        <Checkbox name='insCR' label='Insert Carriage Returns (0x0D) at end of row' />
+      </Form>
+    )
+  }
+}
+
+
 interface ASMExportFormatProps extends ExportPropsBase {
   state: FileFormatAsm['exportOptions'];
 }
@@ -205,6 +223,7 @@ class JsonExportForm extends Component<JsonExportFormatProps> {
 
 interface ExportModalState {
   [key: string]: FileFormat['exportOptions'];
+  seq: FileFormatSeq['exportOptions'];
   png: FileFormatPng['exportOptions'];
   asm: FileFormatAsm['exportOptions'];
   bas: FileFormatBas['exportOptions'];
@@ -245,6 +264,10 @@ class ExportForm extends Component<ExportFormProps> {
         return (
           <PNGExportForm {...connectFormState(this.props, 'png')} />
         )
+      case 'seq':
+        return (
+          <SEQExportForm {...connectFormState(this.props, 'seq')} />
+        )
       case 'asm':
         return (
           <ASMExportForm {...connectFormState(this.props, 'asm')} />
@@ -281,6 +304,9 @@ interface ExportModalDispatch {
 
 class ExportModal_ extends Component<ExportModalProps & ExportModalDispatch, ExportModalState> {
   state: ExportModalState = {
+    seq: {
+      insCR: false,
+    },
     png: {
       borders: true,
       alphaPixel: false,

--- a/src/redux/typesExport.ts
+++ b/src/redux/typesExport.ts
@@ -44,6 +44,7 @@ export interface FileFormatSeq extends FileFormatBase {
   ext: 'seq';
   exportOptions: {
     insCR: boolean;
+    insClear: boolean;
   }
 }
 

--- a/src/redux/typesExport.ts
+++ b/src/redux/typesExport.ts
@@ -42,6 +42,9 @@ export interface FileFormatC extends FileFormatBase {
 
 export interface FileFormatSeq extends FileFormatBase {
   ext: 'seq';
+  exportOptions: {
+    insCR: boolean;
+  }
 }
 
 

--- a/src/utils/exporters/seq.ts
+++ b/src/utils/exporters/seq.ts
@@ -21,10 +21,13 @@ const seq_colors: number[]=[
   0x9b //grey 3
 ]
 
-function convertToSEQ(fb: Framebuf, bytes:number[], insCR: boolean) {
+function convertToSEQ(fb: Framebuf, bytes:number[], insCR: boolean, insClear: boolean) {
   const { width, height, framebuf } = fb
   let currcolor = -1
   let currev = false
+  if (insClear) {
+    bytes.push(0x93)
+  }
   for (let y = 0; y < height; y++) {
     for (let x = 0; x < width; x++) {
       let byte_color = framebuf[y][x].color
@@ -104,10 +107,9 @@ function convertToSEQ(fb: Framebuf, bytes:number[], insCR: boolean) {
 
 const  saveSEQ = (filename: string, fb: FramebufWithFont, fmt: FileFormatSeq) => {
   try {
-    const options = fmt.exportOptions;
+    const {insCR, insClear} = fmt.exportOptions;
     let bytes:number[] = []
-    console.log(fmt) // placeholder for future use
-    convertToSEQ(fb, bytes, options.insCR)
+    convertToSEQ(fb, bytes, insCR, insClear)
     let buf = new Buffer(bytes);
     fs.writeFileSync(filename, buf, null);
   }

--- a/src/utils/exporters/seq.ts
+++ b/src/utils/exporters/seq.ts
@@ -21,7 +21,7 @@ const seq_colors: number[]=[
   0x9b //grey 3
 ]
 
-function convertToSEQ(fb: Framebuf, bytes:number[]) {
+function convertToSEQ(fb: Framebuf, bytes:number[], insCR: boolean) {
   const { width, height, framebuf } = fb
   let currcolor = -1
   let currev = false
@@ -92,14 +92,22 @@ function convertToSEQ(fb: Framebuf, bytes:number[]) {
       bytes.push(byte_char)
 
     }
+    if (insCR) {
+      if (currev){
+        bytes.push(0x0d)
+      } else {
+        bytes.push(0x8d)
+      }
+    }
   }
 }
 
 const  saveSEQ = (filename: string, fb: FramebufWithFont, fmt: FileFormatSeq) => {
   try {
+    const options = fmt.exportOptions;
     let bytes:number[] = []
     console.log(fmt) // placeholder for future use
-    convertToSEQ(fb, bytes)
+    convertToSEQ(fb, bytes, options.insCR)
     let buf = new Buffer(bytes);
     fs.writeFileSync(filename, buf, null);
   }

--- a/src/utils/exporters/seq.ts
+++ b/src/utils/exporters/seq.ts
@@ -92,7 +92,7 @@ function convertToSEQ(fb: Framebuf, bytes:number[], insCR: boolean) {
       bytes.push(byte_char)
 
     }
-    if (insCR) {
+    if (insCR && (y < height - 1)) {
       if (currev){
         bytes.push(0x0d)
       } else {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -52,7 +52,8 @@ export const formats: { [index: string]: FileFormat } = {
     ext: 'seq',
     commonExportParams: defaultExportCommon,
     exportOptions: {
-      insCR: false
+      insCR: false,
+      insClear: true
     }
   },
   c: {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -51,6 +51,9 @@ export const formats: { [index: string]: FileFormat } = {
     name: 'PETSCII .seq',
     ext: 'seq',
     commonExportParams: defaultExportCommon,
+    exportOptions: {
+      insCR: false
+    }
   },
   c: {
     name: 'PETSCII .c',


### PR DESCRIPTION
I've added a format options dialog in seq export to address issue #155 . It adds two options to the user: the first (defaults to false) allows adding a carriage return at the end of each row except the last one, allowing correct display of narrow screens on standard 40 columns.

10x10 petmate sample:
![insCRsample](https://user-images.githubusercontent.com/796799/56869913-b249b100-6a07-11e9-8247-ae9efed93135.png)

Same file exported and loaded on 40 columns screen (without carriage returns):
![insCR1](https://user-images.githubusercontent.com/796799/56869926-f2109880-6a07-11e9-8f6e-8952bd494714.png)

Same file exported and loaded on 40 columns screen (with carriage returns):
![insCR2](https://user-images.githubusercontent.com/796799/56870175-bf689f00-6a0b-11e9-93b1-43ca94236cb8.png)

The second option, if checked (defaults to on), adds a Clear Screen byte at start of file. This basically allows to choose if the sequence should automatically clear the screen before displaying its characters.

This is an example of loading two seq files when the second one (the square X pattern) doesn't clear the previous screen:
![testClsVice](https://user-images.githubusercontent.com/796799/56870638-8aac1600-6a12-11e9-8e0d-31fd23a6c1ae.png)