### PR TITLE
Seq Export: Added option to strip out unnecessary blanks at end of the rows, replacing them with a Carriage Return.

### DIFF
--- a/src/containers/ExportModal.tsx
+++ b/src/containers/ExportModal.tsx
@@ -130,8 +130,9 @@ class SEQExportForm extends Component<SEQExportFormatProps> {
         <Title>SEQ export options</Title>
         <br/>
         <br/>
-        <Checkbox name='insCR' label='Insert Carriage Returns (0x0D) at end of row' />
+        <Checkbox name='insCR' label='Append Carriage Returns at end of rows'/><span></span>
         <Checkbox name='insClear' label='Insert CLS (0x93) at start of file' />
+        <Checkbox name='stripBlanks' label='Optimize sequence' />
       </Form>
     )
   }
@@ -307,7 +308,8 @@ class ExportModal_ extends Component<ExportModalProps & ExportModalDispatch, Exp
   state: ExportModalState = {
     seq: {
       insCR: false,
-      insClear: true
+      insClear: true,
+      stripBlanks: false
     },
     png: {
       borders: true,

--- a/src/redux/typesExport.ts
+++ b/src/redux/typesExport.ts
@@ -45,6 +45,7 @@ export interface FileFormatSeq extends FileFormatBase {
   exportOptions: {
     insCR: boolean;
     insClear: boolean;
+    stripBlanks: boolean;
   }
 }
 

--- a/src/utils/exporters/seq.ts
+++ b/src/utils/exporters/seq.ts
@@ -21,9 +21,9 @@ const seq_colors: number[]=[
   0x9b //grey 3
 ]
 
-function appendCR(bytes:number[], currev:boolean) {
+function appendCR(bytes:number[], currev:boolean, force:boolean) {
   // Append a Carriage Return if not already done
-  if (bytes.length && (bytes[bytes.length -1] & 0x7f) != 0x0d)
+  if (force || (bytes.length && (bytes[bytes.length -1] & 0x7f) != 0x0d))
     bytes.push(currev ? 0x0d : 0x8d)
 }
 
@@ -123,15 +123,17 @@ function convertToSEQ(fb: Framebuf, bytes:number[], insCR:boolean, insClear:bool
 
     // Check if there are blanks left behind
     // In that case substitute them with a Carriage Return
-    if (stripBlanks && blank_buffer.length > 0 && y != lastCRrow) {
-      appendCR(bytes, currev);
-      lastCRrow = y;
-    }
-    blank_buffer = []
+    if (y < height - 1) {
+      if (stripBlanks && blank_buffer.length > 0 && y != lastCRrow) {
+        appendCR(bytes, currev, blank_buffer.length == width);
+        lastCRrow = y;
+      }
+      blank_buffer = []
 
-    if (insCR && (y < height - 1)) {
-      appendCR(bytes, currev);
-      lastCRrow = y;
+      if (insCR) {
+        appendCR(bytes, currev, false);
+        lastCRrow = y;
+      }
     }
   }
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -53,7 +53,8 @@ export const formats: { [index: string]: FileFormat } = {
     commonExportParams: defaultExportCommon,
     exportOptions: {
       insCR: false,
-      insClear: true
+      insClear: true,
+      stripBlanks: false
     }
   },
   c: {


### PR DESCRIPTION
Trailing blanks characters aren't visible, yet they take up space and increase file size when exported as sequence, so with this option the user can choose to replace them with a single Carriage Return after the last visible char.

![testopt](https://user-images.githubusercontent.com/796799/57166368-40ec7280-6dfa-11e9-8f3f-053bdea40e5e.png)

As an example, the above screen, when exported as seq file takes up 1024 bytes, because after the X square pattern rows are still filled with blank chars.
Optimizing sequence strips out those blanks, trimming down file size to 134 bytes.

Another example with a visual representation of the optimization (dots = blanks char, arrows = CR)

Before:
![testopt_before](https://user-images.githubusercontent.com/796799/57168243-3f727880-6e01-11e9-8352-639f9d9ee20f.png)

After:
![testopt_after](https://user-images.githubusercontent.com/796799/57168268-5dd87400-6e01-11e9-9212-ce149ee10924.png)

This option can be safely used with the other one that appends a CR to every row.
