### PR TITLE
Add single chargen file support

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -270,8 +270,21 @@ export const loadAppFile = (filename: string) => {
   return fs.readFileSync(path.resolve(appPath, filename));
 }
 
-export const systemFontData = loadAppFile('assets/system-charset.bin')
-export const systemFontDataLower = loadAppFile('assets/system-charset-lower.bin')
+export const loadFont = (filename: string) => {
+  let fontData , systemFontDataLower, systemFontData
+  try {
+    fontData = loadAppFile(filename)
+    systemFontData = fontData.slice(0, 2048)
+    systemFontDataLower = fontData.slice(2048, 4096)
+  } catch (e) {
+    console.warn(`Charset font ${filename} not found`)
+    systemFontData = loadAppFile('assets/system-charset.bin')
+    systemFontDataLower = loadAppFile('assets/system-charset-lower.bin')
+}
+  return { systemFontData, systemFontDataLower }
+}
+
+export const { systemFontData, systemFontDataLower }  = loadFont('assets/chargen')
 export const executablePrgTemplate = loadAppFile('assets/template.prg')
 
 export function setWorkspaceFilenameWithTitle(setWorkspaceFilename: (fname: string) => void, filename: string) {


### PR DESCRIPTION
I've added very basic support for single chargen files to simplify a bit the use of custom charsets.
The code tries to load a file called "chargen" in the asset folder and, if not present, falls back to normal behaviour and loads the usual couple of charsets files that get shipped with petmate.

This is an example of petmate with an unsettling charset found in the deepest abyss of internet:
![PETZXSCII](https://user-images.githubusercontent.com/796799/68894704-19bb1a00-0728-11ea-9c12-80eeaaa98e33.png)

The chargen file should contain the two charsets (upper and lower case) summing to a total of 4096 bytes, but it can be loaded even if it carries partial character sets, like this example:
![Schermata del 2019-11-14 22-23-18](https://user-images.githubusercontent.com/796799/68897258-6e14c880-072d-11ea-95e3-d39ce6854d17.png)
In the image above the font is "Action wave", and it has been downloaded from [here](http://kofler.dot.at/c64/font_01.html). Here a trick has been used to get the font correctly loaded: its original size is oddly 514 bytes and it has been converted to 512 bytes using the (linux) shell command `tail -c 512 action_wave.64c > chargen` getting rid of the first two bytes.









