### PR TITLE
Scalable png export

### DIFF
--- a/src/components/formHelpers.js
+++ b/src/components/formHelpers.js
@@ -33,12 +33,13 @@ const RadioButton_ = ({label, onChange, checked, value}) => {
   )
 }
 
-const NumberInput_ = ({label, onChange, value}) => {
+const NumberInput_ = ({label, onChange, value, defaultValue}) => {
   console.log(value)
   return (
     <label className={styles.numberInputContainer}>
       {label}
       <input
+        defaultValue={defaultValue}
         style={{minWidth: '4em'}}
         type='number'
         value={value}
@@ -104,13 +105,14 @@ export class RadioButton extends Component {
 export class NumberInput extends Component {
   static propTypes = {
     name: PropTypes.string.isRequired,
-    value: PropTypes.string.isRequired
+    value: PropTypes.string.isRequired,
+    defaultValue: PropTypes.number
   }
 
   render () {
     return (
       <FormContext.Consumer>
-        {({ setField, state}) => <NumberInput_ onChange={(e) => setField(this.props.name, e.target.value)} {...this.props} />}
+        {({ setField, state}) => <NumberInput_ defaultValue={this.props.defaultValue} onChange={(e) => setField(this.props.name, e.target.value)} {...this.props} />}
       </FormContext.Consumer>
     )
   }

--- a/src/containers/ExportModal.tsx
+++ b/src/containers/ExportModal.tsx
@@ -112,8 +112,8 @@ class PNGExportForm extends Component<PNGExportFormatProps> {
         <br/>
         <br/>
         <Checkbox name='alphaPixel' label='Alpha pixel work-around for Twitter' />
-        <Checkbox name='doublePixels' label='Double pixels' />
         <Checkbox name='borders' label='Include borders' />
+        <NumberInput name='scale' label='Scale' />
       </Form>
     )
   }
@@ -328,7 +328,7 @@ class ExportModal_ extends Component<ExportModalProps & ExportModalDispatch, Exp
     png: {
       borders: true,
       alphaPixel: false,
-      doublePixels: false
+      scale: 1,
     },
     asm: {
       assembler: 'kickass',

--- a/src/containers/ExportModal.tsx
+++ b/src/containers/ExportModal.tsx
@@ -113,7 +113,7 @@ class PNGExportForm extends Component<PNGExportFormatProps> {
         <br/>
         <Checkbox name='alphaPixel' label='Alpha pixel work-around for Twitter' />
         <Checkbox name='borders' label='Include borders' />
-        <NumberInput name='scale' label='Scale' />
+        <NumberInput name='scale' label='Scale' defaultValue={1} />
       </Form>
     )
   }

--- a/src/redux/typesExport.ts
+++ b/src/redux/typesExport.ts
@@ -31,9 +31,9 @@ export interface FileFormatGif extends FileFormatBase {
 export interface FileFormatPng extends FileFormatBase {
   ext: 'png';
   exportOptions: {
-    doublePixels: boolean;
     alphaPixel: boolean;
     borders: boolean;
+    scale: number;
   };
 }
 

--- a/src/utils/exporters/png.ts
+++ b/src/utils/exporters/png.ts
@@ -12,8 +12,8 @@ export function savePNG(filename: string, fb: FramebufWithFont, palette: RgbPale
     const { imgWidth, imgHeight } = computeOutputImageDims(fb, options.borders);
 
     const buf = framebufToPixels(fb, palette, options.borders);
-    const scale = options.doublePixels ? 2 : 1;
-    const pixBuf = options.doublePixels ? doublePixels(buf, imgWidth, imgHeight) : buf;
+    const scale = options.scale
+    const pixBuf = options.scale != 1 ? doublePixels(buf, imgWidth, imgHeight, scale) : buf;
     if (options.alphaPixel) {
       // TODO is this enough to fool png->jpeg transcoders heuristics?
       pixBuf[3] = 254;

--- a/src/utils/exporters/png.ts
+++ b/src/utils/exporters/png.ts
@@ -10,10 +10,10 @@ export function savePNG(filename: string, fb: FramebufWithFont, palette: RgbPale
     const options = fmt.exportOptions;
 
     const { imgWidth, imgHeight } = computeOutputImageDims(fb, options.borders);
-
-    const buf = framebufToPixels(fb, palette, options.borders);
     const scale = options.scale
-    const pixBuf = options.scale != 1 ? doublePixels(buf, imgWidth, imgHeight, scale) : buf;
+    const buf = framebufToPixels(fb, palette, options.borders);
+    const pixBuf = scale != 1 ? scalePixels(buf, imgWidth, imgHeight, scale) : buf;
+
     if (options.alphaPixel) {
       // TODO is this enough to fool png->jpeg transcoders heuristics?
       pixBuf[3] = 254;

--- a/src/utils/exporters/png.ts
+++ b/src/utils/exporters/png.ts
@@ -1,6 +1,6 @@
 
 import { FramebufWithFont, FileFormatPng, RgbPalette } from '../../redux/types'
-import { framebufToPixels, doublePixels, computeOutputImageDims } from './util'
+import { framebufToPixels, scalePixels, computeOutputImageDims } from './util'
 import { electron, fs } from '../electronImports'
 
 const nativeImage = electron.nativeImage

--- a/src/utils/exporters/util.ts
+++ b/src/utils/exporters/util.ts
@@ -69,9 +69,9 @@ export function framebufToPixels(fb: FramebufWithFont, palette: RgbPalette, bord
   return buf
 }
 
-export function doublePixels(buf: Buffer, w: number, h: number): Buffer {
-  const dstPitch = 2*w*4
-  const dst = Buffer.alloc(2*w * 2*h * 4)
+export function doublePixels(buf: Buffer, w: number, h: number, scale: number): Buffer {
+  const dstPitch = scale*w*4 // could be 4 needs to be scale * 2
+  const dst = Buffer.alloc(scale*w * scale*h * 4) // same here and down below
   for (let y = 0; y < h; y++) {
     for (let x = 0; x < w; x++) {
       const srcOffs = (x + y*w)*4

--- a/src/utils/exporters/util.ts
+++ b/src/utils/exporters/util.ts
@@ -69,28 +69,28 @@ export function framebufToPixels(fb: FramebufWithFont, palette: RgbPalette, bord
   return buf
 }
 
-export function doublePixels(buf: Buffer, w: number, h: number, scale: number): Buffer {
-  const dstPitch = scale*w*4 // could be 4 needs to be scale * 2
-  const dst = Buffer.alloc(scale*w * scale*h * 4) // same here and down below
-  for (let y = 0; y < h; y++) {
-    for (let x = 0; x < w; x++) {
-      const srcOffs = (x + y*w)*4
-      const dstOffs = (x*2*4 + 2*y*dstPitch)
+export function scalePixels(buf: Buffer, width: number, height: number, scale: number): Buffer {
+
+  const pixelLength = 4;
+  const dstPitch = scale * width * pixelLength // could be 4 needs to be scale * 2
+  const dst = Buffer.alloc(scale * width * scale * height * pixelLength) // same here and down below
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const srcOffs = (x + y * width) * pixelLength
       const b = buf[srcOffs + 0]
       const g = buf[srcOffs + 1]
       const r = buf[srcOffs + 2]
       const a = buf[srcOffs + 3]
 
-      for (let o = 0; o < dstPitch*2; o+=dstPitch) {
-        dst[o + dstOffs + 0] = b
-        dst[o + dstOffs + 1] = g
-        dst[o + dstOffs + 2] = r
-        dst[o + dstOffs + 3] = a
-
-        dst[o + dstOffs + 4] = b
-        dst[o + dstOffs + 5] = g
-        dst[o + dstOffs + 6] = r
-        dst[o + dstOffs + 7] = a
+      const dstOffs = (x * scale * 4 + scale * y * dstPitch)
+      for (let o = 0; o < dstPitch * scale; o += dstPitch) {
+        for (let horizontal = 0; horizontal < scale * 4; horizontal+=4) {
+          dst[o + dstOffs + 0 + horizontal] = b
+          dst[o + dstOffs + 1 + horizontal] = g
+          dst[o + dstOffs + 2 + horizontal] = r
+          dst[o + dstOffs + 3 + horizontal] = a
+        }
       }
     }
   }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -46,7 +46,7 @@ export const formats: { [index: string]: FileFormat } = {
     exportOptions: {
       borders: false,
       alphaPixel: false,
-      doublePixels: false
+      scale: 1
     }
   },
   seq: {


### PR DESCRIPTION
#187 

This allows the user to set the desired scale instead of just selecting double pixels when exporting as png. 